### PR TITLE
Fixed Download for Video Upload on July 13th

### DIFF
--- a/index.php
+++ b/index.php
@@ -131,7 +131,7 @@ function getContent($url, $geturl = false)
 				$thumb = explode("\"",explode('og:image" content="', $resp)[1])[0];
 				$username = explode("/",explode("@",explode("\"",explode("\"canonicalHref\":\"", $resp)[1])[0])[1])[0];
 				$videoKey = getKey($contentURL);
-				$cleanVideo = "https://api.tiktokv.com/aweme/v1/playwm/?video_id=$videoKey&line=0&ratio=default&media_type=4&vr_type=0";
+				$cleanVideo = "https://api2-16-h2.musical.ly/aweme/v1/play/?video_id=$videoKey&line=0&ratio=default&media_type=4&vr_type=0";
 				$cleanVideo = getContent($cleanVideo, true);
 			
 		?>


### PR DESCRIPTION
Fixes #11 

However, I can't find any TikToks to test this endpoint on from July 13-July 27th. Not sure if TikTok made changes after the video I tested this on that would break downloads for the 10 days until they broke the videos without watermark completely.